### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/functions/__touchrunner_list_tasks.fish
+++ b/functions/__touchrunner_list_tasks.fish
@@ -5,7 +5,7 @@ function __touchrunner_list_tasks
 
   if test "$stat" != "$__touchrunner_mtime"
     set -g __touchrunner_mtime $stat
-    set -g __touchrunner_packages (node -e "$__touchrunner_script" ^/dev/null)
+    set -g __touchrunner_packages (node -e "$__touchrunner_script" 2>/dev/null)
   end
 
   printf "%s\n" $__touchrunner_packages


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
